### PR TITLE
Tested on macOS Big Sur (11.5.1)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,7 +96,7 @@ cog will be visible in the menu bar when the processes are running. Once you
 have finished with the server then manually kill the process via the
 drop-down menu from this spinning cog.
 
-The launchers have been tested on macOS Mojave (10.14.6).
+The launchers have been tested on macOS Big Sur (11.5.1).
 
 Installation instructions
 -------------------------


### PR DESCRIPTION
The software was tested on a newer version of macOS.